### PR TITLE
test-e2e: Load the docker image to kind cluster

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,6 @@ on:
 env:
   GO_VERSION: '1.17'
 
-concurrency:
-  group: ci
-  cancel-in-progress: true
-
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -59,18 +55,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set VERSION and deploy the test image
-      run: |
-        echo "VERSION=${VERSION}" >> $GITHUB_ENV
-        echo VERSION ${VERSION}
-        make image VERSION=${VERSION}
-        docker login -u gjkim42 -p "${DOCKER_SECRET}"
-        make push VERSION=${VERSION}
-      env:
-        DOCKER_SECRET: ${{ secrets.GJKIM42_DOCKER_PASSWORD }}
-        VERSION: "test-e2e"
-
     - uses: helm/kind-action@v1.2.0
+      with:
+        cluster_name: kind
 
     - name: Install cert-manager
       run: |
@@ -81,12 +68,15 @@ jobs:
 
     - name: Set DEFAULT_IMAGEPULLSECRETS and deploy default-imagepullsecrets
       run: |
+        make image VERSION=${VERSION}
+        kind load docker-image "gjkim42/default-imagepullsecrets:${VERSION}"
         echo "DEFAULT_IMAGEPULLSECRETS=${DEFAULT_IMAGEPULLSECRETS}" >> $GITHUB_ENV
         envsubst < default-imagepullsecrets.yaml | kubectl apply -f -
         kubectl rollout status -n default-imagepullsecrets deployment default-imagepullsecrets
         kubectl apply -f mutating-webhook-configuration.yaml
       env:
         DEFAULT_IMAGEPULLSECRETS: "mysecret0,my-secret1"
+        VERSION: test-e2e
 
     - uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
Load the docker image to kind cluster in order to not push docker image for only CI purpose.