### PR TITLE
Sync the version of ginkgo cli with the version of ginkgo package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
 
     - name: e2e test
       run: |
-        go install github.com/onsi/ginkgo/v2/ginkgo@latest
+        go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
         ginkgo ./test/e2e -- \
           --kubeconfig=${HOME}/.kube/config \
           --image-pull-secrets=${DEFAULT_IMAGEPULLSECRETS}


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #

This matches the version of ginkgo cli to the version of the imported ginkgo package to maintain compatibility.

#### Does this PR introduce a user-facing change?
```release-note
[TEST] The version of ginkgo CLI used by the e2e test has been synced with the version of ginkgo package to be imported.
```