### PR TITLE
Update Go to v1.19.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: '1.17'
+  GO_VERSION: '1.19.2'
 
 jobs:
   verify:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
     - 'v*'
 
 env:
-  GO_VERSION: '1.17'
+  GO_VERSION: '1.19.2'
 
 jobs:
   release:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gjkim42/default-imagepullsecrets
 
-go 1.17
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.0


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #

#### Does this PR introduce a user-facing change?
```release-note
default-imagepullsecrets is now built with Golang 1.19.2.
```
